### PR TITLE
Make TableViewHeader's delegate a weak reference

### DIFF
--- a/CollapsibleTableSectionViewController/CollapsibleTableViewHeader.swift
+++ b/CollapsibleTableSectionViewController/CollapsibleTableViewHeader.swift
@@ -8,13 +8,13 @@
 
 import UIKit
 
-protocol CollapsibleTableViewHeaderDelegate {
+protocol CollapsibleTableViewHeaderDelegate: class {
     func toggleSection(_ section: Int)
 }
 
 open class CollapsibleTableViewHeader: UITableViewHeaderFooterView {
     
-    var delegate: CollapsibleTableViewHeaderDelegate?
+    weak var delegate: CollapsibleTableViewHeaderDelegate?
     var section: Int = 0
     
     let titleLabel = UILabel()


### PR DESCRIPTION
The strong reference to TableViewHeader's delegate turned out to be the source of a memory leak in my app. Changing this reference to weak allows the parent CollapsibleTableViewController to be properly deallocated.