### PR TITLE
testToggleSection and testTapHeader unit tests

### DIFF
--- a/CollapsibleTableSectionViewControllerTests/CollapsibleTableSectionViewControllerTests.swift
+++ b/CollapsibleTableSectionViewControllerTests/CollapsibleTableSectionViewControllerTests.swift
@@ -274,6 +274,29 @@ class CollapsibleTableSectionViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.toggled, true)
     }
     
+    func testTapHeader() {
+        
+        class MockDelegate: CollapsibleTableViewHeaderDelegate {
+            func toggleSection(_ section: Int) {}
+        }
+        
+        class MockUITapGestureRecognizer: UITapGestureRecognizer {}
+        
+        class MockCollapsibleTableViewHeader: CollapsibleTableViewHeader {
+            public var tapped: Bool = false
+            @objc override func tapHeader(_ gestureRecognizer: UITapGestureRecognizer) {
+                 tapped = true
+            }
+        }
+
+        let header = MockCollapsibleTableViewHeader()
+        let gesture = MockUITapGestureRecognizer()
+        let delegate = MockDelegate()
+        header.delegate = delegate
+        header.tapHeader(gesture)
+        XCTAssertEqual(header.tapped, true)
+    }
+    
     func testReturnsCurrentSectionThatNeedsReload() {
         let sectionsNeedReload = viewController.getSectionsNeedReload(0)
         

--- a/CollapsibleTableSectionViewControllerTests/CollapsibleTableSectionViewControllerTests.swift
+++ b/CollapsibleTableSectionViewControllerTests/CollapsibleTableSectionViewControllerTests.swift
@@ -254,6 +254,26 @@ class CollapsibleTableSectionViewControllerTests: XCTestCase {
     // Test toggleSection
     //
     
+    func testToggleSection() {
+        // Mock the CollapsibleTableViewHeaderDelegate
+        
+        class MockDelegate: CollapsibleTableViewHeaderDelegate {
+            public var toggled: Bool = false
+            func toggleSection(_ section: Int) {
+                toggled = true
+            }
+        }
+        
+        class MockCollapsibleTableViewHeader: CollapsibleTableViewHeader {}
+        
+        let header = MockCollapsibleTableViewHeader()
+        let delegate = MockDelegate()
+        header.delegate = delegate
+        header.delegate?.toggleSection(0)
+        
+        XCTAssertEqual(delegate.toggled, true)
+    }
+    
     func testReturnsCurrentSectionThatNeedsReload() {
         let sectionsNeedReload = viewController.getSectionsNeedReload(0)
         


### PR DESCRIPTION
```tapHeader``` and ```toggleSection``` were without unit tests. This PR adds this two tests cases.

👍  